### PR TITLE
Rejuvenate log levels.

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/apply/DiffApplier.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/DiffApplier.java
@@ -121,7 +121,7 @@ public class DiffApplier extends AbstractService {
 
         int completed = completedFiles.incrementAndGet();
         if (completed % 100 == 0) {
-          logger.log(Level.INFO, String.format("Completed %d files in %s", completed, stopwatch));
+          logger.log(Level.WARNING, String.format("Completed %d files in %s", completed, stopwatch));
         }
       } catch (IOException | DiffNotApplicableException e) {
         logger.log(Level.WARNING, "Failed to apply diff to file " + diff.getRelevantFileName(), e);


### PR DESCRIPTION
Here's a reissue of https://github.com/google/error-prone/pull/1268 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 2000.
The head at the time of analysis was: 2118ba35b0efe2fdfe4b1af35d1967ed935b6988
